### PR TITLE
Reverse order of notes (first note on the first line, last note on the last line)

### DIFF
--- a/kindle-notes-core/src/lib.rs
+++ b/kindle-notes-core/src/lib.rs
@@ -48,7 +48,7 @@ fn create_note(filename: &Path, notes: &[&str]) -> std::io::Result<()> {
         .create(true)
         .open(filename)?;
 
-    for note in notes {
+    for note in notes.iter().rev() {
         writeln!(&mut book_buffer, "{}\n", note).unwrap();
     }
     Ok(())


### PR DESCRIPTION
This commit changes the order of notes in the final `.md` file. The notes are now ordered as they were taken (first note on the first line, last note on the last line).